### PR TITLE
feature: introduce indexed BIDS validation fields for a BIDS dataset

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -209,6 +209,11 @@ export interface BIDSDataset {
 	EventsFileCount?: number
 	Size?: string
 	FileCount?: number
+	BIDSSchemaVersion?: string
+	BIDSErrors?: []
+	BIDSWarnings?: []
+	BIDSIgnored?: []
+	BIDSValid?: boolean
 }
 
 export type IOption = { label: string; inputValue?: string }

--- a/src/components/BIDS/DatasetInfo.tsx
+++ b/src/components/BIDS/DatasetInfo.tsx
@@ -1,3 +1,5 @@
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import { Box, Typography } from '@mui/material'
 import { BIDSDataset } from '../../api/types'
 import * as React from 'react'
@@ -78,6 +80,16 @@ const DatasetInfo = ({ dataset }: { dataset?: BIDSDataset }): JSX.Element => (
 			<Typography variant='body2' color='text.secondary'>
 				Files: <strong>{dataset?.FileCount}</strong>
 			</Typography>
+		</Box>
+		<Box sx={{ display: 'flex', mt: 2, flexWrap: 'wrap', gap: '0px 8px' }}>
+			<Typography variant='body2' color='text.secondary'>
+				BIDS Validation:
+			</Typography>
+			<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0px 8px' }}>
+				{dataset?.BIDSValid ?
+					<CheckIcon sx={{ color: '#009900' }}></CheckIcon> :
+					<CloseIcon sx={{ color: '#cc0000' }}></CloseIcon>}
+			</Box>
 		</Box>
 	</>
 )


### PR DESCRIPTION
This PR is intended to be merged into PR #7 and adds:
- BIDS validation fields to BIDSDataset type
- display of BIDS validity in DatasetInfo